### PR TITLE
[sumo] Use https in github repo SRC_URIS

### DIFF
--- a/meta-security-compliance/recipes-openscap/oe-scap/oe-scap_1.0.bb
+++ b/meta-security-compliance/recipes-openscap/oe-scap/oe-scap_1.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://README.md;md5=46dec9f167b6e05986cb4023df6d92f4"
 LICENSE = "MIT"
 
 SRCREV = "7147871d7f37d408c0dd7720ef0fd3ec1b54ad98"
-SRC_URI = "git://github.com/akuster/oe-scap.git"
+SRC_URI = "git://github.com/akuster/oe-scap.git;protocol=https"
 SRC_URI += " \
 	file://run_cve.sh \
 	file://run_test.sh \

--- a/meta-security-compliance/recipes-openscap/openscap-daemon/openscap-daemon_0.1.6.bb
+++ b/meta-security-compliance/recipes-openscap/openscap-daemon/openscap-daemon_0.1.6.bb
@@ -9,7 +9,7 @@ LICENSE = "LGPL-2.1"
 DEPENDS = "python3-dbus"
 
 SRCREV = "3fd5c75a08223de35a865d026d2a6980ec9c1d74"
-SRC_URI = "git://github.com/OpenSCAP/openscap-daemon.git"
+SRC_URI = "git://github.com/OpenSCAP/openscap-daemon.git;protocol=https"
 
 PV = "0.1.6+git${SRCPV}"
 

--- a/meta-security-compliance/recipes-openscap/openscap/openscap_1.2.15.bb
+++ b/meta-security-compliance/recipes-openscap/openscap/openscap_1.2.15.bb
@@ -12,7 +12,7 @@ DEPENDS = "autoconf-archive pkgconfig gconf procps curl libxml2 rpm \
 DEPENDS_class-native = "autoconf-archive-native pkgconfig-native swig-native curl-native libxml2-native libxslt-native dpkg-native libgcrypt-native nss-native"
 
 SRCREV = "240930d42611983c65ecae16dbca3248ce130921"
-SRC_URI = "git://github.com/akuster/openscap.git;branch=oe \
+SRC_URI = "git://github.com/akuster/openscap.git;branch=oe;protocol=https \
            file://crypto_pkgconfig.patch \
            file://run-ptest \
 "

--- a/meta-security-compliance/recipes-openscap/scap-security-guide/scap-security-guide_0.1.33.bb
+++ b/meta-security-compliance/recipes-openscap/scap-security-guide/scap-security-guide_0.1.33.bb
@@ -9,7 +9,7 @@ LICENSE = "LGPL-2.1"
 DEPENDS = "openscap-native"
 
 SRCREV = "423d9f40021a03abd018bef7818a3a9fe91a083c"
-SRC_URI = "git://github.com/akuster/scap-security-guide.git;branch=oe;"
+SRC_URI = "git://github.com/akuster/scap-security-guide.git;branch=oe;;protocol=https"
 
 inherit cmake
 

--- a/meta-tpm/recipes-tpm/libtpm/libtpm_1.0.bb
+++ b/meta-tpm/recipes-tpm/libtpm/libtpm_1.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=97e5eea8d700d76b3ddfd35c4c96485f"
 
 SRCREV = "3388d45082bdc588c6fc0672f44d6d7d0aaa86ff"
 SRC_URI = " \
-	git://github.com/stefanberger/libtpms.git \
+	git://github.com/stefanberger/libtpms.git;protocol=https \
 	"
 
 S = "${WORKDIR}/git"

--- a/meta-tpm/recipes-tpm/pcr-extend/pcr-extend_git.bb
+++ b/meta-tpm/recipes-tpm/pcr-extend/pcr-extend_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "libtspi"
 PV = "0.1+git${SRCPV}"
 SRCREV = "c02ad8f628b3d99f6d4c087b402fe31a40ee6316"
 
-SRC_URI = "git://github.com/flihp/pcr-extend.git "
+SRC_URI = "git://github.com/flihp/pcr-extend.git;protocol=https"
 
 inherit autotools
 

--- a/meta-tpm/recipes-tpm/swtpm/swtpm_1.0.bb
+++ b/meta-tpm/recipes-tpm/swtpm/swtpm_1.0.bb
@@ -11,7 +11,7 @@ DEPENDS += "tpm-tools-native expect-native socat-native"
 RDEPENDS_${PN} += "tpm-tools"
 
 SRCREV = "4f4f2f0a7e3195f6df8d235d58630a08e69403d8"
-SRC_URI = "git://github.com/stefanberger/swtpm.git \
+SRC_URI = "git://github.com/stefanberger/swtpm.git;protocol=https \
            file://fix_lib_search_path.patch \
            file://fix_fcntl_h.patch \
            file://ioctl_h.patch \

--- a/meta-tpm/recipes-tpm/tpm2-abrmd/tpm2-abrmd_1.2.0.bb
+++ b/meta-tpm/recipes-tpm/tpm2-abrmd/tpm2-abrmd_1.2.0.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=500b2e742befc3da00684d8a1d5fd9da"
 DEPENDS += "autoconf-archive dbus glib-2.0 pkgconfig tpm2.0-tss glib-2.0-native"
 
 SRC_URI = "\
-    git://github.com/01org/tpm2-abrmd.git \
+    git://github.com/01org/tpm2-abrmd.git;protocol=https \
     file://tpm2-abrmd-init.sh \
     file://tpm2-abrmd.default \
 "

--- a/meta-tpm/recipes-tpm/tpm2.0-tools/tpm2.0-tools_git.bb
+++ b/meta-tpm/recipes-tpm/tpm2.0-tools/tpm2.0-tools_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "pkgconfig tpm2.0-tss openssl curl autoconf-archive"
 # July 10, 2017
 SRCREV = "26c0557040c1cf8107fa3ebbcf2a5b07cc84b881"
 
-SRC_URI = "git://github.com/01org/tpm2.0-tools.git;name=tpm2.0-tools;destsuffix=tpm2.0-tools"
+SRC_URI = "git://github.com/01org/tpm2.0-tools.git;name=tpm2.0-tools;destsuffix=tpm2.0-tools;protocol=https"
 
 S = "${WORKDIR}/tpm2.0-tools"
 

--- a/meta-tpm/recipes-tpm/tpm2.0-tss/tpm2.0-tss_1.3.0.bb
+++ b/meta-tpm/recipes-tpm/tpm2.0-tss/tpm2.0-tss_1.3.0.bb
@@ -9,7 +9,7 @@ DEPENDS = "autoconf-archive pkgconfig"
 SRCREV = "b1d9ece8c6bea2e3043943b2edfaebcdca330c38"
 
 SRC_URI = " \
-    git://github.com/tpm2-software/tpm2-tss.git;branch=1.x \
+    git://github.com/tpm2-software/tpm2-tss.git;branch=1.x;protocol=https \
     file://ax_pthread.m4 \
 "
 

--- a/meta-tpm/recipes-tpm/tpm2simulator/tpm2simulator-native_138.bb
+++ b/meta-tpm/recipes-tpm/tpm2simulator/tpm2simulator-native_138.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1415f7be284540b81d9d28c67c1a6b8b"
 DEPENDS = "python"
 
 SRCREV = "e45324eba268723d39856111e7933c5c76238481"
-SRC_URI = "git://github.com/stwagnr/tpm2simulator.git"
+SRC_URI = "git://github.com/stwagnr/tpm2simulator.git;protocol=https"
 
 S = "${WORKDIR}/git"
 OECMAKE_SOURCEPATH = "${S}/cmake"

--- a/recipes-security/clamav/clamav_0.99.3.bb
+++ b/recipes-security/clamav/clamav_0.99.3.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://COPYING.LGPL;beginline=2;endline=3;md5=4b89c05acc7119
 
 SRCREV = "224f73461a44e278e9fa50ba59f51ee5e64373e0"
 
-SRC_URI = "git://github.com/vrtadmin/clamav-devel;branch=rel/0.99 \
+SRC_URI = "git://github.com/vrtadmin/clamav-devel;branch=rel/0.99;protocol=https \
     file://clamd.conf \
     file://freshclam.conf \
     file://volatiles.03_clamav \

--- a/recipes-security/fail2ban/fail2ban_0.10.2.bb
+++ b/recipes-security/fail2ban/fail2ban_0.10.2.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=ecabc31e90311da843753ba772885d9f"
 
 SRCREV ="a45488465e0dd547eb8479c0fa9fd577c1837213"
 SRC_URI = " \
-	git://github.com/fail2ban/fail2ban.git;branch=0.10 \
+	git://github.com/fail2ban/fail2ban.git;branch=0.10;protocol=https \
 	file://initd \
 	file://fail2ban_setup.py \
 "

--- a/recipes-security/fscryptctl/fscryptctl_0.1.0.bb
+++ b/recipes-security/fscryptctl/fscryptctl_0.1.0.bb
@@ -10,7 +10,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 SRCREV = "e4c4d0984dee2531897e13c32a18d5e54a2a4aa6"
-SRC_URI = "git://github.com/google/fscryptctl.git"
+SRC_URI = "git://github.com/google/fscryptctl.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-security/google-authenticator-libpam/google-authenticator-libpam_1.05.bb
+++ b/recipes-security/google-authenticator-libpam/google-authenticator-libpam_1.05.bb
@@ -3,7 +3,7 @@ HOME_PAGE = "https://github.com/google/google-authenticator-libpam"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 LICENSE = "Apache-2.0"
 
-SRC_URI = "git://github.com/google/google-authenticator-libpam.git"
+SRC_URI = "git://github.com/google/google-authenticator-libpam.git;protocol=https"
 SRCREV = "7365ed10d54393fb4c100cac063ae8edb744eac6"
 
 DEPENDS = "libpam"

--- a/recipes-security/libseccomp/libseccomp_2.3.3.bb
+++ b/recipes-security/libseccomp/libseccomp_2.3.3.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;beginline=0;endline=1;md5=8eac08d22113880357c
 
 SRCREV = "74b190e1aa05f07da0c61fb9a30dbc9c18ce2c9d"
 
-SRC_URI = "git://github.com/seccomp/libseccomp.git;branch=release-2.3 \
+SRC_URI = "git://github.com/seccomp/libseccomp.git;branch=release-2.3;protocol=https \
            file://run-ptest \
 "
 

--- a/recipes-security/smack/smack_1.3.1.bb
+++ b/recipes-security/smack/smack_1.3.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
 
 SRCREV = "4a102c7584b39ce693995ffb65e0918a9df98dd8"
 SRC_URI = " \
-	git://github.com/smack-team/smack.git \
+	git://github.com/smack-team/smack.git;protocol=https \
 	file://smack_generator_make_fixup.patch \
 	file://run-ptest"
 

--- a/recipes-security/tripwire/tripwire_2.4.3.6.bb
+++ b/recipes-security/tripwire/tripwire_2.4.3.6.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1c069be8dbbe48e89b580ab4ed86c127"
 SRCREV = "80db91b4c1ca4be9efafd2286e3b2ad32ba4c34c"
 
 SRC_URI = "\
-	git://github.com/Tripwire/tripwire-open-source.git \
+	git://github.com/Tripwire/tripwire-open-source.git;protocol=https \
 	file://tripwire.cron \
 	file://tripwire.sh \
 	file://tripwire.txt \


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

Building the core images in the sumo pipeline revealed that I missed the `tripwire' and 'clamav` packages, and indeed the whole meta-security layer in my last pass to fix all the GH SRC_URIS. This patchset fixes the meta-security layer.

```
...
2022-02-08T11:33:01.8405811Z WARNING: tripwire-2.4.3.6-r0 do_packagedata_setscene: URL: git://github.com/Tripwire/tripwire-open-source.git uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.
...
2022-02-08T11:31:47.3381067Z WARNING: clamav-0.99.3-r0 do_packagedata_setscene: URL: git://github.com/vrtadmin/clamav-devel;branch=rel/0.99 uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url.
...
```

# Testing
`clamav` and `tripwire` now build on my dev machine without throwing a warning about the GH url. I'll additionally validate on the build machines after this PR is merged.

@ni/rtos 