### PR TITLE
meta-security: Currency merge with upstream kirkstone branch

### DIFF
--- a/recipes-mac/smack/smack-test/notroot.py
+++ b/recipes-mac/smack/smack-test/notroot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Script used for running executables with custom labels, as well as custom uid/gid
 # Process label is changed by writing to /proc/self/attr/curent
@@ -9,8 +9,8 @@
 # """By  default,  each  user  in Debian GNU/Linux is given a corresponding group 
 # with the same name. """
 #
-# Usage: root@desk:~# python notroot.py <uid> <label> <full_path_to_executable> [arguments ..]
-# eg: python notroot.py 1000 User::Label /bin/ping -c 3 192.168.1.1
+# Usage: root@desk:~# python3 notroot.py <uid> <label> <full_path_to_executable> [arguments ..]
+# eg: python3 notroot.py 1000 User::Label /bin/ping -c 3 192.168.1.1
 #
 # Author: Alexandru Cornea <alexandru.cornea@intel.com>
 import os
@@ -28,6 +28,6 @@ try:
 	os.setuid(uid)	
 	os.execv(path,sys.argv)
 
-except Exception,e:
-	print e.message
-	sys.exit(1)
+except Exception as e:
+	print(e.strerror)
+	sys.exit(-1)

--- a/recipes-mac/smack/smack-test/smack_test_file_access.sh
+++ b/recipes-mac/smack/smack-test/smack_test_file_access.sh
@@ -8,7 +8,7 @@ CAT=`which cat`
 ECHO=`which echo`
 uid=1000
 initial_label=`cat /proc/self/attr/current`
-python $TMP/notroot.py $uid "TheOther" $ECHO 'TEST' > $test_file
+python3 $TMP/notroot.py $uid "TheOther" $ECHO 'TEST' > $test_file
 chsmack -a "TheOther" $test_file
 
 #        12345678901234567890123456789012345678901234567890123456
@@ -17,7 +17,7 @@ rule_ro="TheOne                  TheOther                r----"
 
 # Remove pre-existent rules for "TheOne TheOther <access>"
 echo -n "$delrule" > $SMACK_PATH/load
-python $TMP/notroot.py $uid "TheOne" $CAT $test_file 2>&1 1>/dev/null | grep -q "Permission denied" || RC=$?
+python3 $TMP/notroot.py $uid "TheOne" $CAT $test_file 2>&1 1>/dev/null | grep -q "Permission denied" || RC=$?
 if [ $RC -ne 0 ]; then
 	echo "Process with different label than the test file and no read access on it can read it"
 	exit $RC
@@ -25,7 +25,7 @@ fi
 
 # adding read access
 echo -n "$rule_ro" > $SMACK_PATH/load
-python $TMP/notroot.py $uid "TheOne" $CAT $test_file | grep -q "TEST" || RC=$?
+python3 $TMP/notroot.py $uid "TheOne" $CAT $test_file | grep -q "TEST" || RC=$?
 if [ $RC -ne 0 ]; then
 	echo "Process with different label than the test file but with read access on it cannot read it"
 	exit $RC
@@ -36,7 +36,7 @@ echo -n "$delrule" > $SMACK_PATH/load
 # changing label of test file to *
 # according to SMACK documentation, read access on a * object is always permitted
 chsmack -a '*' $test_file
-python $TMP/notroot.py $uid "TheOne" $CAT $test_file | grep -q "TEST" || RC=$?
+python3 $TMP/notroot.py $uid "TheOne" $CAT $test_file | grep -q "TEST" || RC=$?
 if [ $RC -ne 0 ]; then
 	echo  "Process cannot read file with * label"
 	exit $RC
@@ -45,7 +45,7 @@ fi
 # changing subject label to *
 # according to SMACK documentation, every access requested by a star labeled subject is rejected
 TOUCH=`which touch`
-python $TMP/notroot.py $uid '*' $TOUCH $TMP/test_file_2
+python3 $TMP/notroot.py $uid '*' $TOUCH $TMP/test_file_2
 ls -la $TMP/test_file_2 2>&1 | grep -q 'No such file or directory' || RC=$?
 if [ $RC -ne 0 ];then
 	echo "Process with label '*' should not have any access"

--- a/recipes-mac/smack/smack-test_1.0.bb
+++ b/recipes-mac/smack/smack-test_1.0.bb
@@ -22,4 +22,4 @@ do_install() {
     install -m 0755 *.sh ${D}${sbindir}
 }
 
-RDEPENDS:${PN} = "smack python mmap-smack-test tcp-smack-test udp-smack-test"
+RDEPENDS:${PN} = "smack python3-core mmap-smack-test tcp-smack-test udp-smack-test"


### PR DESCRIPTION
This is the 2023Q4.2 currency merge with upstream kirkstone branch
There were no merge conflicts and no additional NI-specific patches are required.

[AB#2484331](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2484331)

Testing

* [x] bitbake packagefeed-ni-core
* [x] bitbake packagegroup-ni-desirable

@ni/rtos 