### PR TITLE
smack: Convert CVE_CHECK_IGNORE to CVE_STATUS

### DIFF
--- a/recipes-mac/smack/smack_1.3.1.bb
+++ b/recipes-mac/smack/smack_1.3.1.bb
@@ -13,10 +13,9 @@ SRC_URI = " \
 
 PV = "1.3.1"
 
-# CVE-2014-0363, CVE-2014-0364, CVE-2016-10027 is valnerble for other product.
-CVE_CHECK_IGNORE += "CVE-2014-0363"
-CVE_CHECK_IGNORE += "CVE-2014-0364"
-CVE_CHECK_IGNORE += "CVE-2016-10027"
+CVE_STATUS[CVE-2014-0363] = "not-applicable-config: CVE not for smack of smack-team, but other project."
+CVE_STATUS[CVE-2014-0364] = "not-applicable-config: CVE not for smack of smack-team, but other project."
+CVE_STATUS[CVE-2016-10027] = "not-applicable-config: CVE not for smack of smack-team, but other project"
 
 inherit autotools update-rc.d pkgconfig ptest
 inherit ${@bb.utils.contains('VIRTUAL-RUNTIME_init_manager','systemd','systemd','', d)}


### PR DESCRIPTION
### Summary of Changes
Update `smack_1.3.1.bb` to use `CVE_STATUS` instead of `CVE_CHECK_IGNORE`
Referenced https://git.yoctoproject.org/meta-security/commit/recipes-mac/smack/smack_1.3.1.bb?id=46f7e7acbeee02d46933100a374532a0b9580757 for CVE_STATUS justification

### Justification
Build warning: `CVE_CHECK_IGNORE is deprecated in favor of CVE_STATUS`
[AB#3039626](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039626)



### Testing
Note: The testing was done with CVE_CHECK enabled
* [x] I have built the core package feed with this PR in place. (`bitbake packagefeed-ni-core`)
* [x] I have built the package index with this PR in place. (`bitbake package-index`)

### Procedure

* [x] I certify that the contents of this pull request complies with the [Developer Certificate of Origin](https://github.com/ni/nilrt/blob/HEAD/docs/CONTRIBUTING.md#developer-certificate-of-origin-dco).
