### PR TITLE
tpm2-tools: BBCLASSEXTEND native and nativesdk

### DIFF
--- a/meta-tpm/recipes-tpm2/tpm2-tools/tpm2-tools_5.7.bb
+++ b/meta-tpm/recipes-tpm2/tpm2-tools/tpm2-tools_5.7.bb
@@ -13,3 +13,5 @@ SRC_URI[sha256sum] = "3810d36b5079256f4f2f7ce552e22213d43b1031c131538df8a2dbc3c5
 UPSTREAM_CHECK_URI = "https://github.com/tpm2-software/${BPN}/releases"
 
 inherit autotools pkgconfig bash-completion
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Summary

Cherry-pick an upstream meta-security commit which adds the `native` bbclass to `tpm2-tools`.

This is needed by the `clevis` recipe in scarthgap.


# Testing

* [x] Built the core packagefeed with this change.


# Procedure

* Backport. No cherry-picks necessary.